### PR TITLE
Update Kubeconfig after creating ns

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,5 +27,8 @@ do
    membersArg="-m '$v' $membersArg"
 done
 
-echo running: okteto create namespace $namespace $membersArg
-eval okteto create namespace $namespace $membersArg
+echo running: okteto namespace create $namespace $membersArg
+eval okteto namespace create $namespace $membersArg
+
+echo running: okteto kubeconfig
+eval okteto kubeconfig


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>
Change create namespace to namespace create because of deprecation
Update kubeconfig after changing the namespace