### PR TITLE
Add log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The list of users that will have access to the namespace on Okteto. Separate the
 
 The creator of the namespace will automatically have access to the namespace in Okteto.
 
+### `log-level`
+
+Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)
+
 ## Example usage
 
 This example runs the context action and then activates a namespace.

--- a/action.yml
+++ b/action.yml
@@ -7,12 +7,16 @@ inputs:
   members: 
     description: "Comma-separated list of users that will have access to the namespace in Okteto; you can use either their Okteto username or their email."
     required: false
+  log-level:
+    description: "Log level string. Valid options are debug, info, warn, error"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
     - ${{ inputs.namespace }}
     - ${{ inputs.members }}
+    - ${{ inputs.log-level }}
 branding:
   color: 'green'
   icon: 'grid'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ do
    membersArg="-m '$v' $membersArg"
 done
 
-log_level=$7
+log_level=$3
 if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
     log_level="--log-level ${log_level}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
     log_level="--log-level ${log_level}"
   else
-    echo "log-level supported: debug, info, warn, error"
+    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
     exit 1
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,8 +27,24 @@ do
    membersArg="-m '$v' $membersArg"
 done
 
-echo running: okteto namespace create $namespace $membersArg
-eval okteto namespace create $namespace $membersArg
+log_level=$7
+if [ ! -z "$log_level" ]; then
+  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
+    log_level="--log-level ${log_level}"
+  else
+    echo "log-level supported: debug, info, warn, error"
+    exit 1
+  fi
+fi
+
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+if [ "${RUNNER_DEBUG}" = "1" ]; then
+  log_level="--log-level debug"
+fi
+
+echo running: okteto namespace create $namespace $membersArg $log_level
+eval okteto namespace create $namespace $membersArg $log_level
 
 echo running: okteto kubeconfig
 eval okteto kubeconfig


### PR DESCRIPTION
Resolves https://okteto.atlassian.net/browse/DEV-320

As done for `deploy-preview` this PR adds the input of log-level to the action in order to enable debug logging or any other level the user wants to use on the runs.

Tested running the pipeline using the last commit 
https://github.com/teresaromero/go-getting-started/actions/workflows/test-actions.yml